### PR TITLE
feat: InputForPredicateCreator

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A TypeScript library for defining and executing type-safe data filters. Define y
 
 ```typescript
 import { entity } from "filter-def";
-import type { InputForFilterDef } from "filter-def";
+import type { InputForPredicateCreator } from "filter-def";
 
 interface User {
     name: string;
@@ -20,7 +20,7 @@ const filterUsers = entity<User>().filterDef({
     olderThan: { kind: "gt", field: "age" },
 });
 
-type UserFilterInput = InputForFilterDef<typeof filterUsers>;
+type UserFilterInput = InputForPredicateCreator<typeof filterUsers>;
 
 // Create a predicate function
 const predicate = filterUsers({
@@ -260,7 +260,7 @@ This pattern allows you to:
 
 ```typescript
 import { entity } from "filter-def";
-import type { InputForFilterDef } from "filter-def";
+import type { InputForPredicateCreator } from "filter-def";
 
 interface Product {
     name: string;
@@ -287,7 +287,7 @@ const filterProducts = entity<Product>().filterDef({
     },
 });
 
-type ProductFilterInput = InputForFilterDef<typeof filterProducts>;
+type ProductFilterInput = InputForPredicateCreator<typeof filterProducts>;
 
 // Create a predicate with your filter criteria
 const predicate = filterProducts({

--- a/biome.json
+++ b/biome.json
@@ -12,7 +12,10 @@
     "linter": {
         "enabled": true,
         "rules": {
-            "recommended": true
+            "recommended": true,
+            "suspicious": {
+                "noExplicitAny": "off"
+            }
         }
     },
     "javascript": {

--- a/src/lib/filter-def.ts
+++ b/src/lib/filter-def.ts
@@ -176,10 +176,18 @@ export type CustomFilterDef<TEntity, TInput> = (
 // Filter input
 // ----------------------------------------------------------------
 
+export type InputForPredicateCreator<TPredicateCreator> =
+    TPredicateCreator extends PredicateCreator<infer TEntity, infer TFiltersDef>
+        ? InputForFiltersDef<TEntity, TFiltersDef>
+        : never;
+
 /**
  * Given an Entity and a FiltersDef, create
  */
-type InputForFiltersDef<Entity, TFiltersDef extends FiltersDef<Entity>> = {
+export type InputForFiltersDef<
+    Entity,
+    TFiltersDef extends FiltersDef<Entity>,
+> = {
     [K in keyof TFiltersDef]?: InputForFilterDef<Entity, TFiltersDef[K]>;
 };
 


### PR DESCRIPTION
The `InputForFilterDef` utility type referenced in the README has evolved in complexity and is no longer accurate in the docs or suitable for userland.

This PR introduces a stopgap `InputForPredicateCreator` that essential does the same thing. However, this is meant as a stepping stone to a refactor of naming and general type complexity.