### PR TITLE
feat: make `field` property optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ interface Product {
 
 const productFilter = entity<Product>().filterDef({
     // Primitive filters with inferred fields
-    name: { kind: "equals"}
+    name: { kind: "equals" },
     inStock: { kind: "equals" },
 
     // Primitive filter with explicit fields

--- a/src/lib/filter-def.ts
+++ b/src/lib/filter-def.ts
@@ -72,7 +72,7 @@ export type FilterDef<Entity> = Record<string, FilterField<Entity>>;
  *     // The `name` field wasn't explicitly defined, but it matches the filter name.
  *     name: { kind: 'equals' },
  *
- *     // Even though `emailContains` doesn't  match the `User.email` field,
+ *     // Even though `emailContains` doesn't match the `User.email` field,
  *     // we provided the `field` property to explicitly.
  *     emailContains: { kind: 'contains', field: 'email' }, // `email` field is explicitly defined
  * });
@@ -83,12 +83,11 @@ export type FilterDef<Entity> = Record<string, FilterField<Entity>>;
  *     // to explicitly specify a different, invalid field.
  *     id: { kind: 'equals', field: 'invalidField' },
  *
- *     // `firstName` isn't property of `User`.
+ *     // `firstName` isn't a property of `User`.
  *     firstName: { kind: 'equals' },
  *
  *     // Neither `emailContains` nor `invalidEmail` are valid User properties.
- *     // we provided the `field` property to explicitly.
- *     emailContains: { kind: 'contains', field: 'invalidEmail' }, // `email` field is explicitly defined
+ *     emailContains: { kind: 'contains', field: 'invalidEmail' },
  * });
  *
  * ```
@@ -426,6 +425,7 @@ const compileBooleanFilter = <Entity>(
 ): CompiledFilterChecker<Entity> => {
     const compiledConditions = filterDef.conditions.map((condition) =>
         // Boolean filter conditions must have explicit field property
+        // TODO: Implement field property validation for Boolean filters.
         compilePrimitiveFilter(condition.field as string, condition),
     );
 


### PR DESCRIPTION
Makes the `field` property on a filter optional when the filter's property name matches a property on the entity.

## Example

```typescript
interface User {
  id: string;
  name: string;
}

const userFilter = entity<User>().filterDef({
  // Defining the `field` here is optional, since it is the same as the fitler's name.
  id: { kind: 'equals', field: 'id' },

  // Here, we omit `field`, since it us unnecessary.
  name: { kind: 'equals' },
});

type UserFilter = FilterInput<typeof userFilter>;
//   ^ { id?: string; name?: string }
```